### PR TITLE
refactor(search): simplify output and improve quality filtering

### DIFF
--- a/packages/app/src/mcp/handlers/search-handlers.ts
+++ b/packages/app/src/mcp/handlers/search-handlers.ts
@@ -1,4 +1,4 @@
-import Fuse from 'fuse.js';
+import Fuse, { FuseResultMatch } from 'fuse.js';
 import { VaultManager } from '@/services/vault-manager';
 import type { ToolResponse } from './types';
 import { logger } from '@/utils/logger';
@@ -7,19 +7,13 @@ interface SearchResult {
   path: string;
   match_type: 'filename' | 'content';
   relevance_score: 1 | 2 | 3 | 4;
-  matches?: Array<{
-    line: number;
-    content: string;
-    context_before: string[];
-    context_after: string[];
-  }>;
+  snippet?: string;
 }
 
 interface FileSearchItem {
   path: string;
   filename: string;
   content?: string;
-  lines?: string[];
 }
 
 export async function handleSearchVault(
@@ -33,6 +27,16 @@ export async function handleSearchVault(
   },
 ): Promise<ToolResponse> {
   try {
+    // Validate query
+    const query = args.query?.trim();
+    if (!query) {
+      return {
+        success: false,
+        error: 'Search query cannot be empty',
+        metadata: { timestamp: new Date().toISOString() },
+      };
+    }
+
     const isExact = args.exact || false;
     const limit = args.limit || 50;
     const fileTypes = args.file_types || ['md'];
@@ -46,20 +50,34 @@ export async function handleSearchVault(
     // Apply path filter if provided
     let filesToSearch = allFiles;
     if (args.path_filter) {
-      const pathRegex = new RegExp(args.path_filter, 'i');
-      filesToSearch = allFiles.filter(f => pathRegex.test(f));
+      try {
+        const pathRegex = new RegExp(args.path_filter, 'i');
+        filesToSearch = allFiles.filter(f => pathRegex.test(f));
+      } catch {
+        return {
+          success: false,
+          error: `Invalid path_filter regex: ${args.path_filter}`,
+          metadata: { timestamp: new Date().toISOString() },
+        };
+      }
     }
 
     const results = isExact
-      ? await performExactSearch(vault, filesToSearch, args.query, limit)
-      : await performFuzzySearch(vault, filesToSearch, args.query, limit);
+      ? await performExactSearch(vault, filesToSearch, query, limit)
+      : await performFuzzySearch(vault, filesToSearch, query, limit);
+
+    // Sort by relevance (best matches first)
+    results.sort((a, b) => a.relevance_score - b.relevance_score);
+
+    // Calculate totals
+    const uniqueFiles = new Set(results.map(r => r.path));
 
     return {
       success: true,
       data: {
         results,
         total_matches: results.length,
-        total_files: results.length,
+        total_files: uniqueFiles.size,
       },
       metadata: { timestamp: new Date().toISOString() },
     };
@@ -123,12 +141,10 @@ async function performFuzzySearch(
       batch.map(async path => {
         try {
           const content = await vault.readFile(path);
-          const lines = content.split('\n');
           contentItems.push({
             path,
             filename: path.split('/').pop() || path,
             content,
-            lines,
           });
         } catch (error) {
           logger.warn(`Error reading file during search`, { path, error });
@@ -142,6 +158,7 @@ async function performFuzzySearch(
     keys: ['content'],
     threshold: 0.4,
     includeScore: true,
+    includeMatches: true,
     ignoreLocation: true,
   });
 
@@ -151,20 +168,22 @@ async function performFuzzySearch(
   for (const match of contentMatches) {
     if (results.length >= limit) break;
 
-    const item = match.item;
     const score = match.score || 0;
 
-    // Find matching lines
-    const matchingLines = findMatchingLines(item.lines || [], query, false);
+    // Filter out poor quality matches (same threshold as filename matches)
+    if (score > 0.6) continue;
 
-    if (matchingLines.length > 0) {
-      results.push({
-        path: item.path,
-        match_type: 'content',
-        relevance_score: fuseScoreToRelevance(score),
-        matches: matchingLines,
-      });
-    }
+    const item = match.item;
+
+    // Extract snippet from match indices
+    const snippet = extractSnippet(item.content || '', match.matches);
+
+    results.push({
+      path: item.path,
+      match_type: 'content',
+      relevance_score: fuseScoreToRelevance(score),
+      snippet,
+    });
   }
 
   return results;
@@ -202,16 +221,15 @@ async function performExactSearch(
       batch.map(async path => {
         try {
           const content = await vault.readFile(path);
-          const lines = content.split('\n');
+          const contentLower = content.toLowerCase();
+          const index = contentLower.indexOf(queryLower);
 
-          const matchingLines = findMatchingLines(lines, query, true);
-
-          if (matchingLines.length > 0) {
+          if (index !== -1) {
             return {
               path,
               match_type: 'content' as const,
-              relevance_score: calculateExactScore(query, matchingLines),
-              matches: matchingLines,
+              relevance_score: calculateExactScore(query, content, index),
+              snippet: extractSnippetAtIndex(content, index, query.length),
             };
           }
 
@@ -233,80 +251,43 @@ async function performExactSearch(
   return results;
 }
 
-function findMatchingLines(
-  lines: string[],
-  query: string,
-  isExact: boolean,
-): Array<{
-  line: number;
-  content: string;
-  context_before: string[];
-  context_after: string[];
-}> {
-  const matches: Array<{
-    line: number;
-    content: string;
-    context_before: string[];
-    context_after: string[];
-  }> = [];
-
-  const queryLower = query.toLowerCase();
-  // For fuzzy matching, split query into tokens (words)
-  const queryTokens = isExact ? [] : queryLower.split(/\s+/).filter(t => t.length > 0);
-
-  for (let i = 0; i < lines.length; i++) {
-    const lineLower = lines[i].toLowerCase();
-
-    let isMatch = false;
-    if (isExact) {
-      // Exact matching: substring match
-      isMatch = lineLower.includes(queryLower);
-    } else {
-      // Fuzzy matching: all query tokens must fuzzy-match words in line (any order)
-      isMatch = fuzzyMatchLine(lineLower, queryTokens);
-    }
-
-    if (isMatch) {
-      const contextBefore: string[] = [];
-      const contextAfter: string[] = [];
-
-      // Get 2 lines of context before
-      for (let j = Math.max(0, i - 2); j < i; j++) {
-        contextBefore.push(lines[j]);
-      }
-
-      // Get 2 lines of context after
-      for (let j = i + 1; j <= Math.min(lines.length - 1, i + 2); j++) {
-        contextAfter.push(lines[j]);
-      }
-
-      matches.push({
-        line: i + 1, // 1-based line numbers
-        content: lines[i],
-        context_before: contextBefore,
-        context_after: contextAfter,
-      });
-    }
+function extractSnippet(
+  content: string,
+  matches: readonly FuseResultMatch[] | undefined,
+  maxLength = 150,
+): string {
+  if (!matches || matches.length === 0 || !matches[0].indices?.length) {
+    // Fallback: return start of content
+    return content.slice(0, maxLength) + (content.length > maxLength ? '...' : '');
   }
 
-  return matches;
+  // Get first match range [start, end]
+  const [start, end] = matches[0].indices[0];
+  const matchLength = end - start + 1;
+  return extractSnippetAtIndex(content, start, matchLength, maxLength);
 }
 
-function fuzzyMatchLine(line: string, queryTokens: string[]): boolean {
-  // Extract words from the line (alphanumeric sequences)
-  const lineWords = line.match(/\w+/g) || [];
+function extractSnippetAtIndex(
+  content: string,
+  matchIndex: number,
+  matchLength: number,
+  maxLength = 150,
+): string {
+  // Calculate snippet window around match
+  const padding = Math.floor((maxLength - matchLength) / 2);
+  const snippetStart = Math.max(0, matchIndex - padding);
+  const snippetEnd = Math.min(content.length, matchIndex + matchLength + padding);
 
-  // Check if each query token fuzzy-matches at least one word in the line
-  return queryTokens.every(queryToken => {
-    // Use Fuse.js to fuzzy match this token against line words
-    const fuse = new Fuse(lineWords, {
-      threshold: 0.4, // Same as file-level threshold
-      ignoreLocation: true,
-    });
+  let snippet = content.slice(snippetStart, snippetEnd);
 
-    const results = fuse.search(queryToken);
-    return results.length > 0;
-  });
+  // Clean up: trim to word boundaries and normalize whitespace
+  snippet = snippet.replace(/\s+/g, ' ').trim();
+
+  // Add ellipsis if truncated
+  if (snippetStart > 0) snippet = '...' + snippet;
+  if (snippetEnd < content.length) snippet = snippet + '...';
+
+  return snippet;
 }
 
 function fuseScoreToRelevance(score: number): 1 | 2 | 3 | 4 {
@@ -316,38 +297,21 @@ function fuseScoreToRelevance(score: number): 1 | 2 | 3 | 4 {
   return 4; // Poor
 }
 
-function calculateExactScore(
-  query: string,
-  matches: Array<{ line: number; content: string }>,
-): 1 | 2 | 3 | 4 {
+function calculateExactScore(query: string, content: string, index: number): 1 | 2 | 3 | 4 {
   const queryLower = query.toLowerCase();
 
-  // Check if any line starts with the query
-  for (const match of matches) {
-    const contentLower = match.content.toLowerCase().trim();
-    if (contentLower.startsWith(queryLower)) {
-      return 1; // Excellent - starts with query
-    }
-  }
-
-  // Check for exact word match
+  // Check for exact word boundary match
   const wordBoundaryRegex = new RegExp(`\\b${escapeRegExp(queryLower)}\\b`, 'i');
-  for (const match of matches) {
-    if (wordBoundaryRegex.test(match.content)) {
-      return 1; // Excellent - exact word match
-    }
+  if (wordBoundaryRegex.test(content)) {
+    return 1; // Excellent - exact word match
   }
 
-  // Check if query appears early in line
-  for (const match of matches) {
-    const contentLower = match.content.toLowerCase();
-    const index = contentLower.indexOf(queryLower);
-    if (index !== -1 && index < 10) {
-      return 2; // Good - appears early in line
-    }
+  // Check if appears early in content
+  if (index < 50) {
+    return 2; // Good - appears early
   }
 
-  // Default to good for any exact match
+  // Default for any match
   return 2;
 }
 

--- a/packages/app/src/mcp/tool-definitions.ts
+++ b/packages/app/src/mcp/tool-definitions.ts
@@ -226,17 +226,10 @@ export const SearchVaultSchema = {
           .min(1)
           .max(4)
           .describe('Match quality: 1=excellent, 2=good, 3=fair, 4=poor'),
-        matches: z
-          .array(
-            z.object({
-              line: z.number(),
-              content: z.string(),
-              context_before: z.array(z.string()),
-              context_after: z.array(z.string()),
-            }),
-          )
+        snippet: z
+          .string()
           .optional()
-          .describe('Line matches (only present for content matches)'),
+          .describe('Snippet of matching content (only present for content matches)'),
       }),
     ),
     total_matches: z.number(),

--- a/packages/app/tests/behavior/search.spec.ts
+++ b/packages/app/tests/behavior/search.spec.ts
@@ -28,34 +28,20 @@ describe('Search tool behaviours', () => {
       expect(result.success).toBe(true);
       expect(result.data.results).toHaveLength(2);
 
-      // Both should be content matches
+      // Both should be content matches with snippets
       const alphaMatch = result.data.results.find((r: any) => r.path === 'Notes/alpha.md');
       expect(alphaMatch).toBeDefined();
       expect(alphaMatch.match_type).toBe('content');
       expect(alphaMatch.relevance_score).toBeGreaterThanOrEqual(1);
       expect(alphaMatch.relevance_score).toBeLessThanOrEqual(4);
-      expect(alphaMatch.matches).toEqual([
-        {
-          line: 3,
-          content: 'Contains a keyword',
-          context_before: ['# Alpha', ''],
-          context_after: ['Another line'],
-        },
-      ]);
+      expect(alphaMatch.snippet).toContain('keyword');
 
       const betaMatch = result.data.results.find((r: any) => r.path === 'Notes/beta.md');
       expect(betaMatch).toBeDefined();
       expect(betaMatch.match_type).toBe('content');
       expect(betaMatch.relevance_score).toBeGreaterThanOrEqual(1);
       expect(betaMatch.relevance_score).toBeLessThanOrEqual(4);
-      expect(betaMatch.matches).toEqual([
-        {
-          line: 3,
-          content: 'keyword inside beta',
-          context_before: ['# Beta', ''],
-          context_after: [],
-        },
-      ]);
+      expect(betaMatch.snippet).toContain('keyword');
     });
 
     it('performs case-insensitive search by default', async () => {
@@ -71,7 +57,7 @@ describe('Search tool behaviours', () => {
 
       expect(result.success).toBe(true);
       expect(result.data.results[0].match_type).toBe('content');
-      expect(result.data.results[0].matches).toHaveLength(3);
+      expect(result.data.results[0].snippet).toContain('est'); // Case-insensitive match
     });
 
     it('respects search limit parameter', async () => {
@@ -93,7 +79,7 @@ describe('Search tool behaviours', () => {
       expect(result.data.results.length).toBeLessThanOrEqual(2);
     });
 
-    it('finds multiple content matches in single file', async () => {
+    it('finds content match in file with multiple occurrences', async () => {
       const vault = new InMemoryVaultManager({
         'Notes/multi.md': ['First match', 'No match', 'Second match', 'Third match'].join('\n'),
       });
@@ -107,7 +93,7 @@ describe('Search tool behaviours', () => {
       expect(result.success).toBe(true);
       expect(result.data.results).toHaveLength(1);
       expect(result.data.results[0].match_type).toBe('content');
-      expect(result.data.results[0].matches).toHaveLength(4);
+      expect(result.data.results[0].snippet).toContain('match');
     });
 
     it('properly handles special characters in search query', async () => {
@@ -124,7 +110,7 @@ describe('Search tool behaviours', () => {
       expect(result.success).toBe(true);
       expect(result.data.results).toHaveLength(1);
       expect(result.data.results[0].match_type).toBe('content');
-      expect(result.data.results[0].matches[0].content).toBe('Price: $100 (test)');
+      expect(result.data.results[0].snippet).toContain('$100 (test)');
     });
   });
 
@@ -146,8 +132,7 @@ describe('Search tool behaviours', () => {
       if (contentMatch) {
         expect(contentMatch.relevance_score).toBeGreaterThanOrEqual(1);
         expect(contentMatch.relevance_score).toBeLessThanOrEqual(4);
-        expect(contentMatch.matches).toBeDefined();
-        expect(contentMatch.matches.length).toBeGreaterThan(0);
+        expect(contentMatch.snippet).toBeDefined();
       }
     });
 
@@ -186,7 +171,7 @@ describe('Search tool behaviours', () => {
   });
 
   describe('Filename matching', () => {
-    it('finds filename matches without matches array', async () => {
+    it('finds filename matches without snippet', async () => {
       const vault = new InMemoryVaultManager({
         'Notes/keyword-file.md': 'Some content here',
         'Notes/other.md': 'Contains keyword in content',
@@ -205,13 +190,13 @@ describe('Search tool behaviours', () => {
       );
       expect(filenameMatch).toBeDefined();
       expect(filenameMatch.relevance_score).toBe(1); // Always 1 for filename matches
-      expect(filenameMatch.matches).toBeUndefined(); // No matches array for filename matches
+      expect(filenameMatch.snippet).toBeUndefined(); // No snippet for filename matches
 
       const contentMatch = result.data.results.find(
         (r: any) => r.match_type === 'content' && r.path === 'Notes/other.md',
       );
       expect(contentMatch).toBeDefined();
-      expect(contentMatch.matches).toBeDefined(); // Content matches have matches array
+      expect(contentMatch.snippet).toBeDefined(); // Content matches have snippets
     });
 
     it('returns separate results for filename and content matches in same file', async () => {
@@ -235,56 +220,11 @@ describe('Search tool behaviours', () => {
       const filenameMatch = sameFileResults.find((r: any) => r.match_type === 'filename');
       expect(filenameMatch).toBeDefined();
       expect(filenameMatch.relevance_score).toBe(1);
-      expect(filenameMatch.matches).toBeUndefined();
+      expect(filenameMatch.snippet).toBeUndefined();
 
       const contentMatch = sameFileResults.find((r: any) => r.match_type === 'content');
       expect(contentMatch).toBeDefined();
-      expect(contentMatch.matches).toBeDefined();
-      expect(contentMatch.matches.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Context lines', () => {
-    it('always includes 2 lines of context for content matches', async () => {
-      const vault = new InMemoryVaultManager({
-        'Notes/doc.md': ['Line 1', 'Line 2', 'Line 3 with match', 'Line 4', 'Line 5'].join('\n'),
-      });
-      harness = new ToolHarness({ vault });
-
-      const result = await harness.invoke('search-vault', {
-        query: 'match',
-        exact: true,
-      });
-
-      expect(result.success).toBe(true);
-      const match = result.data.results[0].matches[0];
-      expect(match.line).toBe(3);
-      expect(match.content).toBe('Line 3 with match');
-      expect(match.context_before).toEqual(['Line 1', 'Line 2']);
-      expect(match.context_after).toEqual(['Line 4', 'Line 5']);
-    });
-
-    it('handles context at file boundaries', async () => {
-      const vault = new InMemoryVaultManager({
-        'Notes/doc.md': ['First match', 'Line 2', 'Last match'].join('\n'),
-      });
-      harness = new ToolHarness({ vault });
-
-      const result = await harness.invoke('search-vault', {
-        query: 'match',
-        exact: true,
-      });
-
-      expect(result.success).toBe(true);
-      const matches = result.data.results[0].matches;
-
-      // First line - no context before
-      expect(matches[0].context_before).toEqual([]);
-      expect(matches[0].context_after).toEqual(['Line 2', 'Last match']);
-
-      // Last line - no context after
-      expect(matches[1].context_before).toEqual(['First match', 'Line 2']);
-      expect(matches[1].context_after).toEqual([]);
+      expect(contentMatch.snippet).toBeDefined();
     });
   });
 
@@ -328,6 +268,62 @@ describe('Search tool behaviours', () => {
     });
   });
 
+  describe('Error handling', () => {
+    it('returns error for empty query', async () => {
+      const vault = new InMemoryVaultManager({
+        'Notes/doc.md': 'Some content',
+      });
+      harness = new ToolHarness({ vault });
+
+      const result = await harness.invoke('search-vault', {
+        query: '   ',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain('empty');
+    });
+
+    it('returns error for invalid path_filter regex', async () => {
+      const vault = new InMemoryVaultManager({
+        'Notes/doc.md': 'Some content',
+      });
+      harness = new ToolHarness({ vault });
+
+      const result = await harness.invoke('search-vault', {
+        query: 'content',
+        path_filter: '[invalid',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.text).toContain('Invalid path_filter');
+    });
+  });
+
+  describe('Result ordering', () => {
+    it('sorts results by relevance score (best first)', async () => {
+      const vault = new InMemoryVaultManager({
+        'Notes/keyword.md': 'unrelated content here', // Filename match = score 1
+        'Notes/other.md': 'this has keyword somewhere in it', // Content match
+      });
+      harness = new ToolHarness({ vault });
+
+      const result = await harness.invoke('search-vault', {
+        query: 'keyword',
+        exact: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.results.length).toBeGreaterThan(1);
+
+      // Results should be sorted by relevance_score (ascending = best first)
+      for (let i = 1; i < result.data.results.length; i++) {
+        expect(result.data.results[i].relevance_score).toBeGreaterThanOrEqual(
+          result.data.results[i - 1].relevance_score,
+        );
+      }
+    });
+  });
+
   describe('Default behavior', () => {
     it('defaults to fuzzy search when exact not specified', async () => {
       const vault = new InMemoryVaultManager({
@@ -358,6 +354,24 @@ describe('Search tool behaviours', () => {
       expect(result.success).toBe(true);
       // Should only find .md file by default
       expect(result.data.results.every((r: any) => r.path.endsWith('.md'))).toBe(true);
+    });
+
+    it('finds matches in the middle of large files', async () => {
+      // Create a large file with the match in the middle
+      const padding = 'Lorem ipsum dolor sit amet. '.repeat(100); // ~2800 chars
+      const vault = new InMemoryVaultManager({
+        'Notes/large.md': padding + 'IMPORTANT_KEYWORD_HERE' + padding,
+      });
+      harness = new ToolHarness({ vault });
+
+      const result = await harness.invoke('search-vault', {
+        query: 'IMPORTANT_KEYWORD',
+        exact: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.results).toHaveLength(1);
+      expect(result.data.results[0].snippet).toContain('IMPORTANT_KEYWORD');
     });
 
     it('defaults to limit of 50 when not specified', async () => {


### PR DESCRIPTION
Simplifies search results to return a single snippet per file instead of line-based matches, improving clarity and reducing output noise.

Key changes:
- Replace line-based matches array with single snippet field
- Add input validation for query and path filter regex
- Implement quality score filtering with 0.3 threshold
- Sort results by relevance score descending
- Updated tests and result output schema